### PR TITLE
Feat: 로그인, 회원가입 페이지 기능 구현

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.ts",
+    "css": "src/styles/globals.css",
+    "baseColor": "slate",
+    "cssVariables": false,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils/shadcnUI"
+  }
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,6 +8,8 @@ const nextConfig = {
         hostname: "sprint-fe-project.s3.ap-northeast-2.amazonaws.com",
       },
     ],
+    imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
+    deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,17 @@
       "name": "taskify",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-checkbox": "^1.0.4",
         "axios": "^1.6.5",
+        "class-variance-authority": "^0.7.0",
+        "clsx": "^2.1.0",
+        "lucide-react": "^0.321.0",
         "next": "14.1.0",
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.49.3",
+        "tailwind-merge": "^2.2.1",
+        "tailwindcss-animate": "^1.0.7",
         "usehooks-ts": "^2.9.5"
       },
       "devDependencies": {
@@ -44,7 +50,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -56,7 +61,6 @@
       "version": "7.23.8",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.8.tgz",
       "integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -157,7 +161,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -174,7 +177,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -186,7 +188,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -201,7 +202,6 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
       "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -215,7 +215,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
       "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -224,7 +223,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -232,14 +230,12 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.21",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.21.tgz",
       "integrity": "sha512-SRfKmRe1KvYnxjEMtxEr+J4HIeMX5YBg/qhRHpxEIGjhX1rshcHlnFUE9K0GazhVKWM7B+nARSkV8LuvJdJ5/g==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -398,7 +394,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -411,7 +406,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -420,7 +414,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -433,10 +426,233 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
+      "integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.0.4.tgz",
+      "integrity": "sha512-CBuGQa52aAYnADZVt/KBQzXrwx6TqnlwtcIPGtVt5JkkzQwMOLJjPukimhfKEr4GQNd43C+djUh5Ikopj8pSLg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-use-size": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
+      "integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
+      "integrity": "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
+      "integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-slot": "1.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+      "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
+      "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz",
+      "integrity": "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
+      "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.0.1.tgz",
+      "integrity": "sha512-cV5La9DPwiQ7S0gf/0qiD6YgNqM5Fk97Kdrlc5yBcrF3jyEZQwm7vYFqMo4IfeHgJXsRaMvLABFtd0OVEmZhDw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.0.1.tgz",
+      "integrity": "sha512-ibay+VqrgcaI6veAojjofPATwledXiSmX+C0KrBk/xgpX9rBzPV3OsfwlhQdUOFbh+LKQorLYT+xTXW9V8yd0g==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rushstack/eslint-patch": {
@@ -478,13 +694,13 @@
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.2.48",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.48.tgz",
       "integrity": "sha512-qboRCl6Ie70DQQG9hhNREz81jqC1cs9EVNcjQ1AU+jH6NFfSAhVVbrrY/+nSF+Bsk4AOwm9Qa61InvMCyV+H3w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -495,7 +711,7 @@
       "version": "18.2.18",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.18.tgz",
       "integrity": "sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -504,7 +720,7 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.6",
@@ -773,7 +989,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -782,7 +997,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -796,14 +1010,12 @@
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -815,8 +1027,7 @@
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1063,14 +1274,12 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1089,7 +1298,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -1167,7 +1375,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -1211,7 +1418,6 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1238,7 +1444,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -1246,16 +1451,42 @@
         "node": ">= 6"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.0.tgz",
+      "integrity": "sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==",
+      "dependencies": {
+        "clsx": "2.0.0"
+      },
+      "funding": {
+        "url": "https://joebell.co.uk"
+      }
+    },
+    "node_modules/class-variance-authority/node_modules/clsx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "node_modules/clsx": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1266,8 +1497,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1284,7 +1514,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -1299,7 +1528,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1313,7 +1541,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -1325,7 +1552,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -1407,8 +1634,7 @@
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -1425,8 +1651,7 @@
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -1443,8 +1668,7 @@
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.639",
@@ -1455,8 +1679,7 @@
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
     "node_modules/enhanced-resolve": {
       "version": "5.15.0",
@@ -2039,7 +2262,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
       "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -2055,7 +2277,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -2079,7 +2300,6 @@
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
       "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
-      "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -2100,7 +2320,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -2176,7 +2395,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
       "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
-      "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -2224,7 +2442,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -2238,7 +2455,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2317,7 +2533,6 @@
       "version": "10.3.10",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
       "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
-      "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.3.5",
@@ -2339,7 +2554,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -2351,7 +2565,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -2360,7 +2573,6 @@
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
       "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -2517,7 +2729,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
       "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -2634,7 +2845,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -2674,7 +2884,6 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
       "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
-      "dev": true,
       "dependencies": {
         "hasown": "^2.0.0"
       },
@@ -2701,7 +2910,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2722,7 +2930,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2746,7 +2953,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -2779,7 +2985,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -2933,8 +3138,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.2",
@@ -2953,7 +3157,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
       "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
-      "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -2971,7 +3174,6 @@
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
       "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
-      "dev": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3082,7 +3284,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
       "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -3090,8 +3291,7 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -3129,16 +3329,22 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
       "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
-      "dev": true,
       "engines": {
         "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.321.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.321.0.tgz",
+      "integrity": "sha512-Fi9VahIna6642U+2nAGSjnXwUBV3WyfFFPQq4yi3w30jtqxDLfSyiYCtCYCYQZ2KWNZc1MDI+rcsa0t+ChdYpw==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -3147,7 +3353,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
       "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
       "dependencies": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
@@ -3200,7 +3405,6 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
       "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -3215,7 +3419,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "dependencies": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -3327,7 +3530,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3345,7 +3547,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3354,7 +3555,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -3558,7 +3758,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3566,14 +3765,12 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-scurry": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
       "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^9.1.1 || ^10.0.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -3603,7 +3800,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -3615,7 +3811,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3624,7 +3819,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -3633,7 +3827,6 @@
       "version": "8.4.33",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
       "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3661,7 +3854,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
         "read-cache": "^1.0.0",
@@ -3678,7 +3870,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
       "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-      "dev": true,
       "dependencies": {
         "camelcase-css": "^2.0.1"
       },
@@ -3697,7 +3888,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
       "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3732,7 +3922,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.0.0.tgz",
       "integrity": "sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==",
-      "dev": true,
       "engines": {
         "node": ">=14"
       }
@@ -3741,7 +3930,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
       "integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
-      "dev": true,
       "dependencies": {
         "postcss-selector-parser": "^6.0.11"
       },
@@ -3760,7 +3948,6 @@
       "version": "6.0.15",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.15.tgz",
       "integrity": "sha512-rEYkQOMUCEMhsKbK66tbEU9QVIxbhN18YiniAwA7XQYTVBqrBy+P2p5JcdqsHgKM2zWylp8d7J6eszocfds5Sw==",
-      "dev": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3772,8 +3959,7 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -3828,7 +4014,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3893,7 +4078,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "dependencies": {
         "pify": "^2.3.0"
       }
@@ -3902,7 +4086,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -3933,8 +4116,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.1",
@@ -3957,7 +4139,6 @@
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -3992,7 +4173,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -4037,7 +4217,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4160,7 +4339,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -4172,7 +4350,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4195,7 +4372,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -4232,7 +4408,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -4250,7 +4425,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -4263,14 +4437,12 @@
     "node_modules/string-width-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -4282,7 +4454,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -4362,7 +4533,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -4375,7 +4545,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -4430,7 +4599,6 @@
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
       "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
         "commander": "^4.0.0",
@@ -4464,7 +4632,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4472,11 +4639,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tailwind-merge": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.2.1.tgz",
+      "integrity": "sha512-o+2GTLkthfa5YUt4JxPfzMIpQzZ3adD1vLVkvKE1Twl9UAhGsEbIZhHHZVRttyW177S8PDJI3bTQNaebyofK3Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
       "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
-      "dev": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -4509,6 +4687,14 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tailwindcss-animate": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -4528,7 +4714,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "dependencies": {
         "any-promise": "^1.0.0"
       }
@@ -4537,7 +4722,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
       },
@@ -4549,7 +4733,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -4572,8 +4755,7 @@
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -4769,14 +4951,12 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -4867,7 +5047,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -4885,7 +5064,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -4901,14 +5079,12 @@
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -4922,7 +5098,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -4934,7 +5109,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -4946,7 +5120,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -4973,7 +5146,6 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
       "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
-      "dev": true,
       "engines": {
         "node": ">= 14"
       }

--- a/package.json
+++ b/package.json
@@ -9,11 +9,17 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-checkbox": "^1.0.4",
     "axios": "^1.6.5",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "lucide-react": "^0.321.0",
     "next": "14.1.0",
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.49.3",
+    "tailwind-merge": "^2.2.1",
+    "tailwindcss-animate": "^1.0.7",
     "usehooks-ts": "^2.9.5"
   },
   "devDependencies": {

--- a/src/components/Auth/AuthCheckbox.tsx
+++ b/src/components/Auth/AuthCheckbox.tsx
@@ -1,11 +1,23 @@
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "./AuthInputField/Elements";
+import { Controller } from "react-hook-form";
 
-function AuthCheckbox({ ...props }) {
+function AuthCheckbox({ name, control }: any) {
+  const rules = {
+    required: true,
+  };
+
   return (
     <div className="flex items-center mt-8 gap-8 ">
-      <Checkbox />
-      <Label id="TOS-checkbox" auth>
+      <Controller
+        name={name}
+        control={control}
+        rules={rules}
+        render={({ field }) => (
+          <Checkbox id="TOS-checkbox" ref={field.ref} checked={field.value} onCheckedChange={field.onChange} />
+        )}
+      />
+      <Label htmlFor="TOS-checkbox" auth>
         이용약관에 동의합니다.
       </Label>
     </div>

--- a/src/components/Auth/AuthCheckbox.tsx
+++ b/src/components/Auth/AuthCheckbox.tsx
@@ -1,0 +1,14 @@
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "./AuthInputField/Elements";
+
+function AuthCheckbox({ ...props }) {
+  return (
+    <div className="flex items-center mt-8 gap-8 ">
+      <Checkbox />
+      <Label id="TOS-checkbox" auth>
+        이용약관에 동의합니다.
+      </Label>
+    </div>
+  );
+}
+export default AuthCheckbox;

--- a/src/components/Auth/AuthInputField/Elements.tsx
+++ b/src/components/Auth/AuthInputField/Elements.tsx
@@ -59,4 +59,9 @@ function ErrorMessage({ children }: any) {
   return <div className="text-red text-14">{children}</div>;
 }
 
-export { Input, Label, ErrorMessage };
+function InputContainer({ auth, children }: any) {
+  const gap = auth ? "gap-8" : "gap-10";
+  return <div className={`flex flex-col w-full ${gap}`}>{children}</div>;
+}
+
+export { Input, Label, ErrorMessage, InputContainer };

--- a/src/components/Auth/AuthInputField/Elements.tsx
+++ b/src/components/Auth/AuthInputField/Elements.tsx
@@ -9,7 +9,7 @@ interface InputProps {
   auth?: boolean;
 }
 
-function Input({ id, type, placeholder, isError, auth, ...props }: InputProps) {
+export function Input({ id, type, placeholder, isError, auth, ...props }: InputProps) {
   const [inputType, setInputType] = useState(type);
 
   const handlePasswordVisible = (e: MouseEvent<HTMLButtonElement>) => {
@@ -45,7 +45,7 @@ function Input({ id, type, placeholder, isError, auth, ...props }: InputProps) {
   );
 }
 
-function Label({ children, id, auth }: any) {
+export function Label({ children, id, auth }: any) {
   const AUTH_TEXT = auth ? "" : "tablet:text-18 font-medium tablet:h-21 h-19";
 
   return (
@@ -55,13 +55,11 @@ function Label({ children, id, auth }: any) {
   );
 }
 
-function ErrorMessage({ children }: any) {
+export function ErrorMessage({ children }: any) {
   return <div className="text-red text-14">{children}</div>;
 }
 
-function InputContainer({ auth, children }: any) {
+export function InputContainer({ auth, children }: any) {
   const gap = auth ? "gap-8" : "gap-10";
   return <div className={`flex flex-col w-full ${gap}`}>{children}</div>;
 }
-
-export { Input, Label, ErrorMessage, InputContainer };

--- a/src/components/Auth/AuthInputField/Elements.tsx
+++ b/src/components/Auth/AuthInputField/Elements.tsx
@@ -1,15 +1,19 @@
 import Image from "next/image";
-import { useState, MouseEvent } from "react";
-
+import { useState, MouseEvent, forwardRef, ForwardedRef } from "react";
 interface InputProps {
   id: string;
   type: string;
   placeholder: string;
   isError?: boolean;
   auth?: boolean;
+  autoComplete?: string;
+  onChange: any; // 타입 수정 예정
 }
 
-export function Input({ id, type, placeholder, isError, auth, ...props }: InputProps) {
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { id, type, placeholder, isError, auth, autoComplete, ...props },
+  ref,
+) {
   const [inputType, setInputType] = useState(type);
 
   const handlePasswordVisible = (e: MouseEvent<HTMLButtonElement>) => {
@@ -32,18 +36,20 @@ export function Input({ id, type, placeholder, isError, auth, ...props }: InputP
         id={id}
         type={inputType}
         placeholder={placeholder}
+        autoComplete={autoComplete}
+        ref={ref}
         {...props}
       />
       {type === "password" && (
         <button className="absolute right-16 translate-y-13" onClick={handlePasswordVisible}>
           <div className={`relative ${AUTH_EYEIMG_STYLE}`}>
-            <Image fill src={eyeImage} alt="password toggle" />
+            <Image fill src={eyeImage} alt="password toggle" sizes="24px" />
           </div>
         </button>
       )}
     </div>
   );
-}
+});
 
 export function Label({ children, id, auth }: any) {
   const AUTH_TEXT = auth ? "" : "tablet:text-18 font-medium tablet:h-21 h-19";

--- a/src/components/Auth/AuthInputField/index.tsx
+++ b/src/components/Auth/AuthInputField/index.tsx
@@ -1,6 +1,6 @@
 import { Input, Label, ErrorMessage } from "./Elements";
 import { useState } from "react";
-
+import { Checkbox } from "@/components/ui/checkbox";
 interface AuthInputProps {
   labelName: string;
   id: string;
@@ -26,9 +26,11 @@ function AuthInputField({ labelName, id, type, placeholder, auth, ...props }: Au
 
 function AuthCheckBox({ ...props }) {
   return (
-    <div className="flex items-center mt-8">
-      <input className="w-20 h-20 mr-8 " id="TOS-checkbox" type="checkbox" name="TOS" {...props} />
-      <Label id="TOS-checkbox">이용약관에 동의합니다.</Label>
+    <div className="flex items-center mt-8 gap-8 ">
+      <Checkbox />
+      <Label id="TOS-checkbox" auth>
+        이용약관에 동의합니다.
+      </Label>
     </div>
   );
 }

--- a/src/components/Auth/EmailField .tsx
+++ b/src/components/Auth/EmailField .tsx
@@ -1,0 +1,17 @@
+import { Label, Input, ErrorMessage, InputContainer } from "./AuthInputField/Elements";
+import { useState } from "react";
+
+function EmailField({ ...props }) {
+  const [errorMsg, setErrorMsg] = useState(null);
+  return (
+    <InputContainer auth>
+      <Label id="email" auth>
+        이메일
+      </Label>
+      <Input id="email" type="email" placeholder="이메일을 입력해 주세요" isError={!!errorMsg} auth {...props} />
+      {errorMsg && <ErrorMessage>{errorMsg}</ErrorMessage>}
+    </InputContainer>
+  );
+}
+
+export default EmailField;

--- a/src/components/Auth/EmailField .tsx
+++ b/src/components/Auth/EmailField .tsx
@@ -1,15 +1,31 @@
 import { Label, Input, ErrorMessage, InputContainer } from "./AuthInputField/Elements";
-import { useState } from "react";
+import { Controller } from "react-hook-form";
 
-function EmailField({ ...props }) {
-  const [errorMsg, setErrorMsg] = useState(null);
+const EMAIL_REG = /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
+
+function EmailField({ control, errors, name }: any) {
+  const rules = {
+    required: "이메일을 입력해주세요.",
+    pattern: {
+      value: EMAIL_REG,
+      message: "이메일 형식으로 작성해 주세요.",
+    },
+  };
+
   return (
     <InputContainer auth>
-      <Label id="email" auth>
+      <Label id={name} auth>
         이메일
       </Label>
-      <Input id="email" type="email" placeholder="이메일을 입력해 주세요" isError={!!errorMsg} auth {...props} />
-      {errorMsg && <ErrorMessage>{errorMsg}</ErrorMessage>}
+      <Controller
+        name={name}
+        control={control}
+        rules={rules}
+        render={({ field }) => (
+          <Input id={name} type={name} placeholder="이메일을 입력해 주세요" {...field} isError={!!errors[name]} auth />
+        )}
+      />
+      {errors[name] && <ErrorMessage>{errors[name]?.message}</ErrorMessage>}
     </InputContainer>
   );
 }

--- a/src/components/Auth/NameField.tsx
+++ b/src/components/Auth/NameField.tsx
@@ -1,15 +1,28 @@
 import { Label, Input, ErrorMessage, InputContainer } from "./AuthInputField/Elements";
-import { useState } from "react";
+import { Controller } from "react-hook-form";
 
-function NameField({ ...props }) {
-  const [errorMsg, setErrorMsg] = useState(null);
+function NameField({ control, errors, name }: any) {
+  const rules = {
+    required: "닉네임을 입력해주세요.",
+    maxLength: {
+      value: 10,
+      message: "열 자 이하로 작성해주세요.",
+    },
+  };
   return (
     <InputContainer auth>
-      <Label id="nickname" auth>
+      <Label id={name} auth>
         닉네임
       </Label>
-      <Input id="nickname" type="text" placeholder="닉네임을 입력해 주세요" isError={!!errorMsg} auth {...props} />
-      {errorMsg && <ErrorMessage>{errorMsg}</ErrorMessage>}
+      <Controller
+        name={name}
+        control={control}
+        rules={rules}
+        render={({ field }) => (
+          <Input id={name} type="text" placeholder="닉네임을 입력해 주세요" {...field} isError={!!errors[name]} auth />
+        )}
+      />
+      {errors[name] && <ErrorMessage>{errors[name]?.message}</ErrorMessage>}
     </InputContainer>
   );
 }

--- a/src/components/Auth/NameField.tsx
+++ b/src/components/Auth/NameField.tsx
@@ -1,0 +1,17 @@
+import { Label, Input, ErrorMessage, InputContainer } from "./AuthInputField/Elements";
+import { useState } from "react";
+
+function NameField({ ...props }) {
+  const [errorMsg, setErrorMsg] = useState(null);
+  return (
+    <InputContainer auth>
+      <Label id="nickname" auth>
+        닉네임
+      </Label>
+      <Input id="nickname" type="text" placeholder="닉네임을 입력해 주세요" isError={!!errorMsg} auth {...props} />
+      {errorMsg && <ErrorMessage>{errorMsg}</ErrorMessage>}
+    </InputContainer>
+  );
+}
+
+export default NameField;

--- a/src/components/Auth/PasswordCheckField.tsx
+++ b/src/components/Auth/PasswordCheckField.tsx
@@ -1,22 +1,36 @@
 import { Label, Input, ErrorMessage, InputContainer } from "./AuthInputField/Elements";
-import { useState } from "react";
+import { Controller } from "react-hook-form";
 
-function PasswordCheckField({ ...props }) {
-  const [errorMsg, setErrorMsg] = useState(null);
+function PasswordCheckField({ control, errors, name, password }: any) {
+  const rules = {
+    required: "비밀번호를 확인해 주세요",
+    validate: {
+      checkPassword: (value: string) => password === value || "비밀번호가 일치하지 않습니다.",
+    },
+  };
+
   return (
     <InputContainer auth>
       <Label id="password" auth>
-        비밀번호 확인
+        비밀번호
       </Label>
-      <Input
-        id="password"
-        type="password"
-        placeholder="비밀번호를 한번 더 입력해 주세요"
-        isError={!!errorMsg}
-        auth
-        {...props}
+      <Controller
+        name={name}
+        control={control}
+        rules={rules}
+        render={({ field }) => (
+          <Input
+            id={name}
+            type="password"
+            placeholder="비밀번호를 한번 더 입력해 주세요"
+            {...field}
+            isError={!!errors[name]}
+            auth
+            autoComplete="off"
+          />
+        )}
       />
-      {errorMsg && <ErrorMessage>{errorMsg}</ErrorMessage>}
+      {errors[name] && <ErrorMessage>{errors[name]?.message}</ErrorMessage>}
     </InputContainer>
   );
 }

--- a/src/components/Auth/PasswordCheckField.tsx
+++ b/src/components/Auth/PasswordCheckField.tsx
@@ -1,0 +1,24 @@
+import { Label, Input, ErrorMessage, InputContainer } from "./AuthInputField/Elements";
+import { useState } from "react";
+
+function PasswordCheckField({ ...props }) {
+  const [errorMsg, setErrorMsg] = useState(null);
+  return (
+    <InputContainer auth>
+      <Label id="password" auth>
+        비밀번호 확인
+      </Label>
+      <Input
+        id="password"
+        type="password"
+        placeholder="비밀번호를 한번 더 입력해 주세요"
+        isError={!!errorMsg}
+        auth
+        {...props}
+      />
+      {errorMsg && <ErrorMessage>{errorMsg}</ErrorMessage>}
+    </InputContainer>
+  );
+}
+
+export default PasswordCheckField;

--- a/src/components/Auth/PasswordField.tsx
+++ b/src/components/Auth/PasswordField.tsx
@@ -1,0 +1,24 @@
+import { Label, Input, ErrorMessage, InputContainer } from "./AuthInputField/Elements";
+import { useState } from "react";
+
+function PasswordField({ ...props }) {
+  const [errorMsg, setErrorMsg] = useState(null);
+  return (
+    <InputContainer auth>
+      <Label id="password" auth>
+        비밀번호
+      </Label>
+      <Input
+        id="password"
+        type="password"
+        placeholder="비밀번호를 입력해 주세요"
+        isError={!!errorMsg}
+        auth
+        {...props}
+      />
+      {errorMsg && <ErrorMessage>{errorMsg}</ErrorMessage>}
+    </InputContainer>
+  );
+}
+
+export default PasswordField;

--- a/src/components/Auth/PasswordField.tsx
+++ b/src/components/Auth/PasswordField.tsx
@@ -1,22 +1,41 @@
 import { Label, Input, ErrorMessage, InputContainer } from "./AuthInputField/Elements";
-import { useState } from "react";
+import { Controller } from "react-hook-form";
 
-function PasswordField({ ...props }) {
-  const [errorMsg, setErrorMsg] = useState(null);
+function PasswordField({ control, errors, name, triggerPasswordCheck }: any) {
+  const rules = {
+    required: "비밀번호를 입력해 주세요",
+    minLength: {
+      value: 8,
+      message: "8자 이상 작성해 주세요.",
+    },
+  };
+
   return (
     <InputContainer auth>
       <Label id="password" auth>
         비밀번호
       </Label>
-      <Input
-        id="password"
-        type="password"
-        placeholder="비밀번호를 입력해 주세요"
-        isError={!!errorMsg}
-        auth
-        {...props}
+      <Controller
+        name={name}
+        control={control}
+        rules={rules}
+        render={({ field }) => (
+          <Input
+            id={name}
+            type={name}
+            {...field}
+            onChange={async (values: string) => {
+              await field.onChange(values);
+              triggerPasswordCheck();
+            }}
+            placeholder="비밀번호를 입력해 주세요"
+            isError={!!errors[name]}
+            auth
+            autoComplete="off"
+          />
+        )}
       />
-      {errorMsg && <ErrorMessage>{errorMsg}</ErrorMessage>}
+      {errors[name] && <ErrorMessage>{errors[name]?.message}</ErrorMessage>}
     </InputContainer>
   );
 }

--- a/src/components/Auth/PasswordField.tsx
+++ b/src/components/Auth/PasswordField.tsx
@@ -26,7 +26,7 @@ function PasswordField({ control, errors, name, triggerPasswordCheck }: any) {
             {...field}
             onChange={async (values: string) => {
               await field.onChange(values);
-              triggerPasswordCheck();
+              if (triggerPasswordCheck) return triggerPasswordCheck();
             }}
             placeholder="비밀번호를 입력해 주세요"
             isError={!!errors[name]}

--- a/src/components/modal/Alert/index.tsx
+++ b/src/components/modal/Alert/index.tsx
@@ -1,15 +1,25 @@
 import Modal from "@/components/common/Modal";
 import React from "react";
 
+export type AlertType = "passwordMismatch" | "emailInUse" | "userNotFound" | "serverError" | "";
+
 interface AlertModalProps {
   modalType: "alert" | "delete";
+  alertType?: AlertType;
   callback?: any;
   onClose: () => void;
 }
 
-function AlertModal({ modalType, callback, onClose }: AlertModalProps) {
+function AlertModal({ modalType, callback, onClose, alertType }: AlertModalProps) {
+  const alertMessage = {
+    passwordMismatch: "비밀번호가 일치하지 않습니다.",
+    emailInUse: "이미 사용중인 이메일입니다.",
+    userNotFound: "존재하지 않는 유저입니다.",
+    serverError: "서버 처리중 에러가 발생했습니다. 잠시 후 다시 시도해주세요.",
+  };
+
   const text = {
-    alert: "비밀번호가 일치하지 않습니다.",
+    alert: alertType && `${alertMessage[alertType]}`,
     delete: "컬럼의 모든 카드가 삭제됩니다.",
   };
 

--- a/src/components/modal/alert/index.tsx
+++ b/src/components/modal/alert/index.tsx
@@ -1,15 +1,25 @@
 import Modal from "@/components/common/Modal";
 import React from "react";
 
+export type AlertType = "passwordMismatch" | "emailInUse" | "userNotFound" | "serverError" | "";
+
 interface AlertModalProps {
   modalType: "alert" | "delete";
+  alertType?: AlertType;
   callback?: any;
   onClose: () => void;
 }
 
-function AlertModal({ modalType, callback, onClose }: AlertModalProps) {
+function AlertModal({ modalType, callback, onClose, alertType }: AlertModalProps) {
+  const alertMessage = {
+    passwordMismatch: "비밀번호가 일치하지 않습니다.",
+    emailInUse: "이미 사용중인 이메일입니다.",
+    userNotFound: "존재하지 않는 유저입니다.",
+    serverError: "서버 처리중 에러가 발생했습니다. 잠시 후 다시 시도해주세요.",
+  };
+
   const text = {
-    alert: "비밀번호가 일치하지 않습니다.",
+    alert: alertType && `${alertMessage[alertType]}`,
     delete: "컬럼의 모든 카드가 삭제됩니다.",
   };
 

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Check } from "lucide-react";
+
+import { cn } from "@/lib/shadcnUI/utils";
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-20 w-20 shrink-0 rounded-4 border border-gray-D9D9 bg-white ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-7874 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-violet data-[state=checked]:text-white dark:border-slate-800 dark:border-slate-50 dark:ring-offset-slate-950 dark:focus-visible:ring-slate-300 dark:data-[state=checked]:bg-slate-50 dark:data-[state=checked]:text-slate-900",
+      className,
+    )}
+    {...props}>
+    <CheckboxPrimitive.Indicator className={cn("flex items-center justify-center text-current")}>
+      <Check className="h-20 w-20" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };

--- a/src/layouts/auth/Form.tsx
+++ b/src/layouts/auth/Form.tsx
@@ -7,6 +7,7 @@ interface AuthFormProps {
   type: AuthType;
   children: ReactNode;
   disabled?: boolean;
+  onSubmit: any; // 수정예정
 }
 
 function AuthForm({ type, children, disabled, onSubmit }: AuthFormProps) {

--- a/src/layouts/auth/Form.tsx
+++ b/src/layouts/auth/Form.tsx
@@ -9,15 +9,15 @@ interface AuthFormProps {
   disabled?: boolean;
 }
 
-function AuthForm({ type, children, disabled }: AuthFormProps) {
+function AuthForm({ type, children, disabled, onSubmit }: AuthFormProps) {
   const FORM_TYPE = AUTH_MAPPING[type];
 
   return (
     <section>
-      <form className="flex flex-col gap-16">
+      <form className="flex flex-col gap-16" onSubmit={onSubmit}>
         {children}
         <div className="pt-4">
-          <Button variant="filled" buttonType="auth" disabled={disabled}>
+          <Button variant="filled" buttonType="auth" disabled={disabled} type="submit">
             {FORM_TYPE.button}
           </Button>
         </div>

--- a/src/layouts/auth/Form.tsx
+++ b/src/layouts/auth/Form.tsx
@@ -2,28 +2,22 @@ import Button from "@/components/common/Button/Button";
 import { AuthType } from ".";
 import { ReactNode } from "react";
 import { AUTH_MAPPING } from "@/lib/constants";
-
+import { AuthType } from ".";
 interface AuthFormProps {
-  type: "logIn" | "signUp" | "profile" | "password";
+  type: AuthType;
   children: ReactNode;
   disabled?: boolean;
 }
-
-type Variant = "filled" | "filled_4" | "ghost" | "ghost_gray";
-type ButtonType = "auth" | "confirm" | "modal" | "delete" | "comment";
 
 function AuthForm({ type, children, disabled }: AuthFormProps) {
   const FORM_TYPE = AUTH_MAPPING[type];
 
   return (
     <section>
-      <form className={`${FORM_TYPE.formStyle}`}>
+      <form className="flex flex-col gap-16">
         {children}
-        <div className={`${FORM_TYPE.buttonStyle}`}>
-          <Button
-            variant={FORM_TYPE.buttonVariant as Variant}
-            buttonType={FORM_TYPE.buttonType as ButtonType}
-            disabled={disabled}>
+        <div className="pt-4">
+          <Button variant="filled" buttonType="auth" disabled={disabled}>
             {FORM_TYPE.button}
           </Button>
         </div>

--- a/src/layouts/auth/Header.tsx
+++ b/src/layouts/auth/Header.tsx
@@ -12,10 +12,10 @@ function AuthHeader({ type }: AuthHeaderProps) {
     <header className="w-full flex flex-col justify-center items-center gap-11 tablet:gap-12 pc:gap-14 mb-40 pc:mb-38">
       <Link className="flex flex-col items-end  max-w-544" href="/">
         <span className=" relative w-98 h-114 tablet:w-165 tablet:h-190">
-          <Image src="/images/logo.png" fill alt="logo" />
+          <Image src="/images/logo.png" fill alt="logo" priority sizes="150px" />
         </span>
         <span className=" relative w-120 h-33 mt-18 tablet:mt-30 tablet:w-199 tablet:h-55">
-          <Image src="/images/Taskify.png" fill alt="Taskify" />
+          <Image src="/images/Taskify.png" fill alt="Taskify" priority sizes="150px" />
         </span>
       </Link>
       <div className="text-20 font-medium text-black-3332">{AUTH_MAPPING[type].welcomeMsg}</div>

--- a/src/layouts/auth/index.tsx
+++ b/src/layouts/auth/index.tsx
@@ -1,6 +1,5 @@
 import { ReactNode } from "react";
 import AuthHeader from "./Header";
-import AuthForm from "./Form";
 import AuthFooter from "./Footer";
 
 export type AuthType = "logIn" | "signUp";
@@ -8,17 +7,14 @@ export type AuthType = "logIn" | "signUp";
 interface AuthLayoutProps {
   type: AuthType;
   children: ReactNode;
-  disabled: boolean;
 }
 
-function AuthLayout({ type, children, disabled }: AuthLayoutProps) {
+function AuthLayout({ type, children }: AuthLayoutProps) {
   return (
     <div className="flex items-center justify-center min-h-screen bg-gray-FAFA">
       <div className="px-12 py-48 mx-auto  w-544">
         <AuthHeader type={type} />
-        <AuthForm type={type} disabled={disabled}>
-          {children}
-        </AuthForm>
+        {children}
         <AuthFooter type={type} />
       </div>
     </div>

--- a/src/lib/services/auth/index.ts
+++ b/src/lib/services/auth/index.ts
@@ -1,13 +1,13 @@
 import { authAddress } from "../address";
 import { ServiceResponse, service } from "../axios";
-import { ChangePasswordRequestDto, LoginRequestDto, UserServiceReponseDto } from "./schema";
+import { ChangePasswordRequestDto, LoginRequestDto, UserServiceResponseDto } from "./schema";
 /**
  * 사용자 로그인을 위한 함수입니다.
  *
  * @param {LoginRequestDto} data - 로그인 요청에 필요한 사용자 데이터
- * @returns {Promise<ServiceResponse<UserServiceReponseDto>>} 사용자 서비스 응답 데이터를 포함하는 프로미스
+ * @returns {Promise<ServiceResponse<UserServiceResponseDto>>} 사용자 서비스 응답 데이터를 포함하는 프로미스
  */
-export const login = (data: LoginRequestDto): Promise<ServiceResponse<UserServiceReponseDto>> =>
+export const login = (data: LoginRequestDto): Promise<ServiceResponse<UserServiceResponseDto>> =>
   service("post", authAddress.loginAuth, data);
 /**
  * 사용자 비밀번호 변경을 위한 함수입니다.

--- a/src/lib/services/auth/schema.ts
+++ b/src/lib/services/auth/schema.ts
@@ -1,10 +1,11 @@
-export type UserServiceReponseDto = {
+export type UserServiceResponseDto = {
   id: number;
   email: string;
   nickname: string;
-  profileImageUrl: string;
+  profileImageUrl: string | null;
   createdAt: string;
   updatedAt: string;
+  accessToken: string;
 };
 
 export type LoginRequestDto = {

--- a/src/lib/services/users/index.ts
+++ b/src/lib/services/users/index.ts
@@ -1,15 +1,15 @@
 import { HttpMethod, ServiceResponse, service } from "../axios";
 import { userAddress } from "../address";
-import { UserServiceReponseDto } from "../auth/schema";
+import { UserServiceResponseDto } from "../auth/schema";
 import { CreateUserRequestDto, UpdateMyInfoRequestDto, updateMyInfoResponseDto } from "./schema";
 
 /**
  * 새로운 사용자를 등록하는 함수입니다.
  *
  * @param {CreateUserRequestDto} data - 사용자 등록을 위한 데이터
- * @returns {Promise<ServiceResponse<UserServiceReponseDto>>} 서비스 응답을 포함하는 프로미스
+ * @returns {Promise<ServiceResponse<UserServiceResponseDto>>} 서비스 응답을 포함하는 프로미스
  */
-export const register = (data: CreateUserRequestDto): Promise<ServiceResponse<UserServiceReponseDto>> =>
+export const register = (data: CreateUserRequestDto): Promise<ServiceResponse<UserServiceResponseDto>> =>
   service("post", userAddress.user, data);
 
 /**
@@ -17,13 +17,13 @@ export const register = (data: CreateUserRequestDto): Promise<ServiceResponse<Us
  *
  * @param {HttpMethod} method - 사용할 HTTP 메소드 ('get' 또는 'put')
  * @param {UpdateMyInfoRequestDto} [data] - 사용자 정보 업데이트를 위한 데이터
- * @returns {Promise<ServiceResponse<UserServiceReponseDto>>} 서비스 응답을 포함하는 프로미스
+ * @returns {Promise<ServiceResponse<UserServiceResponseDto>>} 서비스 응답을 포함하는 프로미스
  * @throws {Error} 유효하지 않은 HTTP 메소드가 제공될 경우 오류를 발생시킵니다.
  */
 export const me = (
   method: HttpMethod,
   data: UpdateMyInfoRequestDto,
-): Promise<ServiceResponse<UserServiceReponseDto>> => {
+): Promise<ServiceResponse<UserServiceResponseDto>> => {
   if (method === "put") {
     return service(method, userAddress.mypage, data);
   } else if (method === "get") {

--- a/src/lib/shadcnUI/utils.ts
+++ b/src/lib/shadcnUI/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -25,7 +25,7 @@ export default function Login() {
     control,
     handleSubmit,
     formState: { errors, isValid, isDirty },
-  } = useForm({ defaultValues: LOGIN_FORM, mode: "onChange" });
+  } = useForm({ defaultValues: LOGIN_FORM, mode: "onTouched" });
 
   const router = useRouter();
 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,12 +1,13 @@
+import { useState } from "react";
+import { useRouter } from "next/router";
+import { useForm } from "react-hook-form";
+import { useToggle } from "usehooks-ts";
 import AuthLayout from "@/layouts/auth";
+import AuthForm from "@/layouts/auth/Form";
 import EmailField from "@/components/Auth/EmailField ";
 import PasswordField from "@/components/Auth/PasswordField";
-import AuthForm from "@/layouts/auth/Form";
-import { useForm } from "react-hook-form";
 import { login } from "@/lib/services/auth";
-import { useRouter } from "next/router";
-import AlertModal from "@/components/modal/alert";
-import { useToggle } from "usehooks-ts";
+import AlertModal, { AlertType } from "@/components/modal/alert";
 
 interface LoginForm {
   email: string;
@@ -15,6 +16,7 @@ interface LoginForm {
 
 export default function Login() {
   const [alertValue, alertToggle, setAlertValue] = useToggle();
+  const [alertType, setAlertType] = useState<AlertType>("");
   const LOGIN_FORM = {
     email: "",
     password: "",
@@ -23,8 +25,7 @@ export default function Login() {
     control,
     handleSubmit,
     formState: { errors, isValid, isDirty },
-    setError,
-  } = useForm({ defaultValues: LOGIN_FORM, mode: "onBlur" });
+  } = useForm({ defaultValues: LOGIN_FORM, mode: "onChange" });
 
   const router = useRouter();
 
@@ -40,18 +41,18 @@ export default function Login() {
       if (response.errorMessage) {
         switch (response.errorMessage) {
           case "존재하지 않는 유저입니다.":
-            setError("email", {
-              type: "manual",
-              message: `${response.errorMessage}`,
-            });
+            setAlertType("userNotFound");
+            setAlertValue(true);
             break;
           case "비밀번호가 일치하지 않습니다.":
+            setAlertType("passwordMismatch");
             setAlertValue(true);
             break;
         }
       }
     } catch (error) {
-      alert("서버 처리중 에러가 발생했습니다. 잠시 후 다시 시도해주세요."); // 화면상에서 에러 표시 처리
+      setAlertType("serverError");
+      setAlertValue(true);
     }
   };
 
@@ -63,7 +64,7 @@ export default function Login() {
           <PasswordField name="password" control={control} errors={errors} />
         </AuthForm>
       </AuthLayout>
-      {alertValue && <AlertModal modalType="alert" onClose={() => setAlertValue(false)} />}
+      {alertValue && <AlertModal modalType="alert" alertType={alertType} onClose={() => setAlertValue(false)} />}
     </>
   );
 }

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -3,8 +3,18 @@ import EmailField from "@/components/Auth/EmailField ";
 import PasswordField from "@/components/Auth/PasswordField";
 import AuthForm from "@/layouts/auth/Form";
 import { useForm } from "react-hook-form";
+import { login } from "@/lib/services/auth";
+import { useRouter } from "next/router";
+import AlertModal from "@/components/modal/alert";
+import { useToggle } from "usehooks-ts";
+
+interface LoginForm {
+  email: string;
+  password: string;
+}
 
 export default function Login() {
+  const [alertValue, alertToggle, setAlertValue] = useToggle();
   const LOGIN_FORM = {
     email: "",
     password: "",
@@ -16,16 +26,44 @@ export default function Login() {
     setError,
   } = useForm({ defaultValues: LOGIN_FORM, mode: "onBlur" });
 
-  const onSubmit = (data: object) => {
-    console.log(data);
+  const router = useRouter();
+
+  const onSubmit = async (data: LoginForm) => {
+    try {
+      const response = await login(data);
+      if (response.data) {
+        const accessToken = response.data?.accessToken;
+        localStorage.setItem("accessToken", accessToken);
+        router.push("/mydashboard");
+        return;
+      }
+      if (response.errorMessage) {
+        switch (response.errorMessage) {
+          case "존재하지 않는 유저입니다.":
+            setError("email", {
+              type: "manual",
+              message: `${response.errorMessage}`,
+            });
+            break;
+          case "비밀번호가 일치하지 않습니다.":
+            setAlertValue(true);
+            break;
+        }
+      }
+    } catch (error) {
+      alert("서버 처리중 에러가 발생했습니다. 잠시 후 다시 시도해주세요."); // 화면상에서 에러 표시 처리
+    }
   };
 
   return (
-    <AuthLayout type="logIn">
-      <AuthForm onSubmit={handleSubmit(onSubmit)} type="logIn" disabled={!isDirty || !isValid}>
-        <EmailField name="email" control={control} errors={errors} />
-        <PasswordField name="password" control={control} errors={errors} />
-      </AuthForm>
-    </AuthLayout>
+    <>
+      <AuthLayout type="logIn">
+        <AuthForm onSubmit={handleSubmit(onSubmit)} type="logIn" disabled={!isDirty || !isValid}>
+          <EmailField name="email" control={control} errors={errors} />
+          <PasswordField name="password" control={control} errors={errors} />
+        </AuthForm>
+      </AuthLayout>
+      {alertValue && <AlertModal modalType="alert" onClose={() => setAlertValue(false)} />}
+    </>
   );
 }

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,12 +1,31 @@
 import AuthLayout from "@/layouts/auth";
 import EmailField from "@/components/Auth/EmailField ";
 import PasswordField from "@/components/Auth/PasswordField";
+import AuthForm from "@/layouts/auth/Form";
+import { useForm } from "react-hook-form";
 
 export default function Login() {
+  const LOGIN_FORM = {
+    email: "",
+    password: "",
+  };
+  const {
+    control,
+    handleSubmit,
+    formState: { errors, isValid, isDirty },
+    setError,
+  } = useForm({ defaultValues: LOGIN_FORM, mode: "onBlur" });
+
+  const onSubmit = (data: object) => {
+    console.log(data);
+  };
+
   return (
-    <AuthLayout type="logIn" disabled>
-      <EmailField />
-      <PasswordField />
+    <AuthLayout type="logIn">
+      <AuthForm onSubmit={handleSubmit(onSubmit)} type="logIn" disabled={!isDirty || !isValid}>
+        <EmailField name="email" control={control} errors={errors} />
+        <PasswordField name="password" control={control} errors={errors} />
+      </AuthForm>
     </AuthLayout>
   );
 }

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,11 +1,12 @@
 import AuthLayout from "@/layouts/auth";
-import { AuthInputField } from "@/components/Auth/AuthInputField";
+import EmailField from "@/components/Auth/EmailField ";
+import PasswordField from "@/components/Auth/PasswordField";
 
 export default function Login() {
   return (
     <AuthLayout type="logIn" disabled>
-      <AuthInputField labelName="이메일" type="email" id="email" placeholder="이메일을 입력해 주세요" auth />
-      <AuthInputField labelName="비밀번호" type="password" id="password" placeholder="비밀번호를 입력해 주세요" auth />
+      <EmailField />
+      <PasswordField />
     </AuthLayout>
   );
 }

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,19 +1,17 @@
 import AuthLayout from "@/layouts/auth";
 import { AuthInputField, AuthCheckBox } from "@/components/Auth/AuthInputField";
+import EmailField from "@/components/Auth/EmailField ";
+import NameField from "@/components/Auth/NameField";
+import PasswordField from "@/components/Auth/PasswordField";
+import PasswordCheckField from "@/components/Auth/PasswordCheckField";
 
 export default function SignUp() {
   return (
     <AuthLayout type="signUp" disabled>
-      <AuthInputField labelName="이메일" type="email" id="email" placeholder="이메일을 입력해 주세요" auth />
-      <AuthInputField labelName="닉네임" type="text" id="nickname" placeholder="닉네임을 입력해 주세요" auth />
-      <AuthInputField labelName="비밀번호" type="password" id="password" placeholder="비밀번호를 입력해 주세요" auth />
-      <AuthInputField
-        labelName="비밀번호 확인"
-        type="password"
-        id="password-check"
-        placeholder="비밀번호를 한번 더 입력해 주세요"
-        auth
-      />
+      <EmailField />
+      <NameField />
+      <PasswordField />
+      <PasswordCheckField />
       <AuthCheckBox />
     </AuthLayout>
   );

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,5 +1,5 @@
 import AuthLayout from "@/layouts/auth";
-import { AuthInputField, AuthCheckBox } from "@/components/Auth/AuthInputField";
+import AuthCheckbox from "@/components/Auth/AuthCheckbox";
 import EmailField from "@/components/Auth/EmailField ";
 import NameField from "@/components/Auth/NameField";
 import PasswordField from "@/components/Auth/PasswordField";
@@ -12,7 +12,7 @@ export default function SignUp() {
       <NameField />
       <PasswordField />
       <PasswordCheckField />
-      <AuthCheckBox />
+      <AuthCheckbox />
     </AuthLayout>
   );
 }

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,13 +1,22 @@
+import { useToggle } from "usehooks-ts";
+import { useState } from "react";
+import { useForm, useWatch } from "react-hook-form";
+import { useRouter } from "next/router";
 import AuthLayout from "@/layouts/auth";
+import AuthForm from "@/layouts/auth/Form";
 import AuthCheckbox from "@/components/Auth/AuthCheckbox";
 import EmailField from "@/components/Auth/EmailField ";
 import NameField from "@/components/Auth/NameField";
 import PasswordField from "@/components/Auth/PasswordField";
 import PasswordCheckField from "@/components/Auth/PasswordCheckField";
-import AuthForm from "@/layouts/auth/Form";
-import { useForm, useWatch } from "react-hook-form";
+import { register } from "@/lib/services/users";
+import { CreateUserRequestDto } from "@/lib/services/users/schema";
+import AlertModal, { AlertType } from "@/components/modal/alert";
 
 export default function SignUp() {
+  const [alertValue, alertToggle, setAlertValue] = useToggle();
+  const [alertType, setAlertType] = useState<AlertType>("");
+
   const SIGN_UP_FORM = {
     email: "",
     nickname: "",
@@ -15,16 +24,31 @@ export default function SignUp() {
     passwordCheck: "",
     agreeCheck: false,
   };
+
   const {
     control,
     handleSubmit,
     formState: { errors, isValid, isDirty, touchedFields },
-    setError,
     trigger,
   } = useForm({ defaultValues: SIGN_UP_FORM, mode: "onChange" });
 
-  const onSubmit = (data: object) => {
-    console.log(data);
+  const router = useRouter();
+
+  const onSubmit = async (data: CreateUserRequestDto) => {
+    try {
+      const response = await register(data);
+      if (response.data) {
+        router.push("/login");
+        return;
+      }
+      if (response.errorMessage) {
+        setAlertType("emailInUse");
+        setAlertValue(true);
+      }
+    } catch (error) {
+      setAlertType("serverError");
+      setAlertValue(true);
+    }
   };
 
   const password = useWatch({ control, name: "password" });
@@ -36,14 +60,22 @@ export default function SignUp() {
   };
 
   return (
-    <AuthLayout type="signUp">
-      <AuthForm onSubmit={handleSubmit(onSubmit)} type="signUp" disabled={!isDirty || !isValid}>
-        <EmailField name="email" control={control} errors={errors} />
-        <NameField name="nickname" control={control} errors={errors} />
-        <PasswordField name="password" control={control} errors={errors} triggerPasswordCheck={triggerPasswordCheck} />
-        <PasswordCheckField name="passwordCheck" control={control} errors={errors} password={password} />
-        <AuthCheckbox name="agreeCheck" control={control} />
-      </AuthForm>
-    </AuthLayout>
+    <>
+      <AuthLayout type="signUp">
+        <AuthForm onSubmit={handleSubmit(onSubmit)} type="signUp" disabled={!isDirty || !isValid}>
+          <EmailField name="email" control={control} errors={errors} />
+          <NameField name="nickname" control={control} errors={errors} />
+          <PasswordField
+            name="password"
+            control={control}
+            errors={errors}
+            triggerPasswordCheck={triggerPasswordCheck}
+          />
+          <PasswordCheckField name="passwordCheck" control={control} errors={errors} password={password} />
+          <AuthCheckbox name="agreeCheck" control={control} />
+        </AuthForm>
+      </AuthLayout>
+      {alertValue && <AlertModal modalType="alert" alertType={alertType} onClose={() => setAlertValue(false)} />}
+    </>
   );
 }

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -30,7 +30,7 @@ export default function SignUp() {
     handleSubmit,
     formState: { errors, isValid, isDirty, touchedFields },
     trigger,
-  } = useForm({ defaultValues: SIGN_UP_FORM, mode: "onChange" });
+  } = useForm({ defaultValues: SIGN_UP_FORM, mode: "onTouched" });
 
   const router = useRouter();
 

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -4,15 +4,46 @@ import EmailField from "@/components/Auth/EmailField ";
 import NameField from "@/components/Auth/NameField";
 import PasswordField from "@/components/Auth/PasswordField";
 import PasswordCheckField from "@/components/Auth/PasswordCheckField";
+import AuthForm from "@/layouts/auth/Form";
+import { useForm, useWatch } from "react-hook-form";
 
 export default function SignUp() {
+  const SIGN_UP_FORM = {
+    email: "",
+    nickname: "",
+    password: "",
+    passwordCheck: "",
+    agreeCheck: false,
+  };
+  const {
+    control,
+    handleSubmit,
+    formState: { errors, isValid, isDirty, touchedFields },
+    setError,
+    trigger,
+  } = useForm({ defaultValues: SIGN_UP_FORM, mode: "onChange" });
+
+  const onSubmit = (data: object) => {
+    console.log(data);
+  };
+
+  const password = useWatch({ control, name: "password" });
+
+  const triggerPasswordCheck = () => {
+    if (touchedFields.passwordCheck) {
+      trigger("passwordCheck");
+    }
+  };
+
   return (
-    <AuthLayout type="signUp" disabled>
-      <EmailField />
-      <NameField />
-      <PasswordField />
-      <PasswordCheckField />
-      <AuthCheckbox />
+    <AuthLayout type="signUp">
+      <AuthForm onSubmit={handleSubmit(onSubmit)} type="signUp" disabled={!isDirty || !isValid}>
+        <EmailField name="email" control={control} errors={errors} />
+        <NameField name="nickname" control={control} errors={errors} />
+        <PasswordField name="password" control={control} errors={errors} triggerPasswordCheck={triggerPasswordCheck} />
+        <PasswordCheckField name="passwordCheck" control={control} errors={errors} password={password} />
+        <AuthCheckbox name="agreeCheck" control={control} />
+      </AuthForm>
     </AuthLayout>
   );
 }


### PR DESCRIPTION
## 요구사항

### 회원가입
- [x] 입력값 유효성 검사 
- [x] 회원가입 페이지 폼 서버 제출 기능
- [x] 회원가입 성공 시 로그인 페이지 이동 
- [x] 사용 중인 이메일일 경우 alert 모달 띄우기
- [x] 서버에러의 경우 alert 모달 띄우기 (추가) 


### 로그인
- [x] 입력값 유효성 검사 
- [x] 로그인 페이지 폼 서버 제출 기능
- [x] 로그인 성공 시  /mydashboard 이동
- [x] 로그인 성공시 accessToken 로컬 스토리지 저장
- [x] 유효한 이메일이 아닌 경우 alert 모달 띄우기
- [x] 비밀번호가 일치하지 않을 경우 alert 모달 띄우기
- [x] 서버에러의 경우 alert 모달 띄우기 (추가) 

## 작업 진행 상황

- (중요) 기존 AuthInputField를 EmailField, PasswordField,NameField..등 input 타입 별로 분리해서 회원가입 페이지 로그인 페이지에 적용 했습니다..  사용중이신 분 계실 까봐 일단 그대로 두긴 했는데 사용을 안하게 된다면 지울 예정입니다..
- alert 모달 좀 수정했습니다..
- UserServiceResponseDto에서 UserServiceRe's'ponseDto s가 빠져서 오타수정했습니다.. 
- 타입 얼렁 넣겠습니다..

## 스크린샷

### 로그인 페이지

https://github.com/codeit-part3-team7/Taskify/assets/148737398/ccfa01a1-cf11-4751-b4a5-71979fdd3074

### 회원가입 페이지

https://github.com/codeit-part3-team7/Taskify/assets/148737398/3b747e08-8838-4f83-831e-53be485f874b





